### PR TITLE
Add back and delete buttons to novel writer interface

### DIFF
--- a/src/components/novel/SimpleNovelWriter.tsx
+++ b/src/components/novel/SimpleNovelWriter.tsx
@@ -20,11 +20,14 @@ export default function SimpleNovelWriter() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
-  // Load saved content on mount
+  // Load saved content on mount (safely for SSR)
   useEffect(() => {
-    const savedContent = localStorage.getItem('novel_content');
-    if (savedContent) {
-      setEditorContent(savedContent);
+    // Only access localStorage in the browser environment
+    if (typeof window !== 'undefined') {
+      const savedContent = localStorage.getItem('novel_content');
+      if (savedContent) {
+        setEditorContent(savedContent);
+      }
     }
   }, []);
 
@@ -33,8 +36,8 @@ export default function SimpleNovelWriter() {
     const words = countWords(editorContent);
     setChapterWordCount(words);
     
-    // Save content to localStorage
-    if (editorContent) {
+    // Save content to localStorage (safely for SSR)
+    if (typeof window !== 'undefined' && editorContent) {
       localStorage.setItem('novel_content', editorContent);
     }
   }, [editorContent]);
@@ -223,7 +226,9 @@ BEGIN CONTINUATION NOW:`;
     if (showDeleteConfirm) {
       // Clear the content and localStorage
       setEditorContent('');
-      localStorage.removeItem('novel_content');
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('novel_content');
+      }
       toast.success('Novel deleted successfully');
       setShowDeleteConfirm(false);
     } else {

--- a/src/components/novel/SimpleNovelWriter.tsx
+++ b/src/components/novel/SimpleNovelWriter.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { Loader2, Sparkles, Play, Pause } from 'lucide-react';
+import { Loader2, Sparkles, Play, Pause, ArrowLeft, Trash2 } from 'lucide-react';
 import { sendChatMessage } from '@/services/api';
 import { countWords } from '@/lib/utils';
 import { toast } from 'sonner';
 import { Progress } from '@/components/ui/progress';
+import { useRouter } from 'next/navigation';
 
 export default function SimpleNovelWriter() {
+  const router = useRouter();
   const [editorContent, setEditorContent] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [autoPilotMode, setAutoPilotMode] = useState(false);
@@ -15,12 +17,26 @@ export default function SimpleNovelWriter() {
   const [chapterWordCount, setChapterWordCount] = useState(0);
   const [selectedModel] = useState('gpt-3.5-turbo');
   const [selectedLanguage] = useState('indonesian');
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
-  // Update word count when editor content changes
+  // Load saved content on mount
+  useEffect(() => {
+    const savedContent = localStorage.getItem('novel_content');
+    if (savedContent) {
+      setEditorContent(savedContent);
+    }
+  }, []);
+
+  // Update word count when editor content changes and save content
   useEffect(() => {
     const words = countWords(editorContent);
     setChapterWordCount(words);
+    
+    // Save content to localStorage
+    if (editorContent) {
+      localStorage.setItem('novel_content', editorContent);
+    }
   }, [editorContent]);
 
   // Clean up interval on unmount
@@ -197,10 +213,50 @@ BEGIN CONTINUATION NOW:`;
   // Calculate progress percentage
   const progressPercentage = chapterWordCount > 0 ? Math.min(100, (chapterWordCount / 2000) * 100) : 0;
 
+  // Handle back navigation
+  const handleBack = () => {
+    router.back();
+  };
+
+  // Handle novel deletion
+  const handleDelete = () => {
+    if (showDeleteConfirm) {
+      // Clear the content and localStorage
+      setEditorContent('');
+      localStorage.removeItem('novel_content');
+      toast.success('Novel deleted successfully');
+      setShowDeleteConfirm(false);
+    } else {
+      setShowDeleteConfirm(true);
+      // Auto-hide the confirmation after 3 seconds
+      setTimeout(() => setShowDeleteConfirm(false), 3000);
+    }
+  };
+
   return (
     <div className="container mx-auto p-4 max-w-6xl">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold">Simple Novel Writer (2000 Words per Chapter)</h1>
+        <div className="flex items-center space-x-4">
+          <Button 
+            variant="outline" 
+            size="sm" 
+            onClick={handleBack}
+            className="flex items-center gap-1"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back
+          </Button>
+          <h1 className="text-2xl font-bold">Simple Novel Writer (2000 Words per Chapter)</h1>
+        </div>
+        <Button 
+          variant={showDeleteConfirm ? "destructive" : "outline"} 
+          size="sm" 
+          onClick={handleDelete}
+          className="flex items-center gap-1"
+        >
+          <Trash2 className="h-4 w-4" />
+          {showDeleteConfirm ? "Confirm Delete" : "Delete Novel"}
+        </Button>
       </div>
       
       <div className="grid grid-cols-1 gap-4">


### PR DESCRIPTION
## Description
This PR adds back and delete buttons to the novel writer interface as requested.

### Changes:
- Added a back button to navigate to the previous page
- Added a delete button with confirmation to delete the novel
- Implemented localStorage persistence for novel content with SSR compatibility
- Added appropriate icons and styling for the buttons

### Vercel Deployment Compatibility:
- Added SSR-safe localStorage access to prevent hydration errors
- Ensured code passes all TypeScript and ESLint checks
- Successfully tested with `npm run build`

### Testing:
- Tested back navigation functionality
- Tested delete functionality with confirmation
- Verified that content is properly saved to and loaded from localStorage

### Notes:
The back button uses the router's back() function to navigate to the previous page, and the delete button clears the content and removes it from localStorage.
